### PR TITLE
Require Fog to be enabled before using effect

### DIFF
--- a/Assets/FadeToSkybox/Editor/FadeToSkyboxEditor.cs
+++ b/Assets/FadeToSkybox/Editor/FadeToSkyboxEditor.cs
@@ -19,16 +19,26 @@ public class FadeToSkyboxEditor : Editor
 
     public override void OnInspectorGUI()
     {
-        if (FadeToSkybox.CheckSkybox())
+        bool componentSupported = true;
+
+        if (!FadeToSkybox.CheckSkybox())
+        {
+            EditorGUILayout.HelpBox("This component only supports cubed skyboxes.", MessageType.Warning);
+            componentSupported = false;
+        }
+
+        if (!RenderSettings.fog)
+        {
+            EditorGUILayout.HelpBox("This component requires fog to be enabled (Window -> Lighting -> Fog).", MessageType.Warning);
+            componentSupported = false;
+        }
+
+        if (componentSupported)
         {
             serializedObject.Update();
             EditorGUILayout.PropertyField(_useRadialDistance);
             EditorGUILayout.PropertyField(_startDistance);
             serializedObject.ApplyModifiedProperties();
-        }
-        else
-        {
-            EditorGUILayout.HelpBox("This component only supports cubed skyboxes.", MessageType.Warning);
         }
     }
 }

--- a/Assets/FadeToSkybox/FadeToSkybox.cs
+++ b/Assets/FadeToSkybox/FadeToSkybox.cs
@@ -30,6 +30,7 @@ public class FadeToSkybox : MonoBehaviour
 
     public static bool CheckSkybox()
     {
+        // Check for cubed skybox
         var skybox = RenderSettings.skybox;
         return skybox != null &&
                skybox.HasProperty("_Tex") &&
@@ -73,9 +74,9 @@ public class FadeToSkybox : MonoBehaviour
     [ImageEffectOpaque]
     void OnRenderImage(RenderTexture source, RenderTexture destination)
     {
-        if (!CheckSkybox())
+        if (!CheckSkybox() || 
+            !RenderSettings.fog)
         {
-            // The current skybox isn't cubed one.
             Graphics.Blit(source, destination);
             return;
         }


### PR DESCRIPTION
In Fog is not enabled, there are no valid shader variants that can be
selected from.  In the Editor, Unity will silently choose another
variant, and not mention that no valid variants are usable by the
effect.  However, when you generate a stand-alone build, visual
corruption will happen due to the FadeToSkybox.shader not being used.

We can check for Fog being enabled, and also print out an error in the
Component dialog box.  Additionally, if Fog is not enabled, the shader